### PR TITLE
Get attestation report and build OVMF with TPM2 enabled

### DIFF
--- a/libtpm.h
+++ b/libtpm.h
@@ -6,6 +6,7 @@
 #include "ExecCommand_fp.h"
 #include "wolfssl/openssl/bn.h"
 #include "wolfssl/openssl/ssl.h"
+#include "wolfssl/wolfcrypt/sha512.h"
 
 #define TPM_ALG_RSA                     (ALG_RSA_VALUE)
 #define TPM_RC_SUCCESS                  (0x000)

--- a/libtpm.h
+++ b/libtpm.h
@@ -6,6 +6,7 @@
 #include "ExecCommand_fp.h"
 #include "wolfssl/openssl/bn.h"
 #include "wolfssl/openssl/ssl.h"
+#include "wolfssl/wolfcrypt/aes.h"
 #include "wolfssl/wolfcrypt/sha512.h"
 
 #define TPM_ALG_RSA                     (ALG_RSA_VALUE)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -119,7 +119,7 @@ build_install_ovmf()
 	fi
 
 	# captures all the OVMF debug messages on qemu serial log. remove -DDEBUG_ON_SERIAL_PORT to disable it.
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT -DTPM2_ENABLE -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
 
 	if [ ! -d ovmf ]; then
 		run_cmd git clone --single-branch -b ${OVMF_BRANCH} ${OVMF_GIT_URL} ovmf

--- a/scripts/stable-commits
+++ b/scripts/stable-commits
@@ -14,6 +14,10 @@ if [ "$VTPM" == "1" ]; then
 	# qemu commit
 	QEMU_GIT_URL="https://github.com/svsm-vtpm/qemu.git"
 	QEMU_BRANCH="svsm-vtpm-preview"
+
+	# Guest BIOS (OVMF)
+	OVMF_GIT_URL="https://github.com/svsm-vtpm/ovmf.git"
+	OVMF_BRANCH="svsm-vtpm-preview"
 else
 	# Hypervisor commit
 	KERNEL_GIT_URL="https://github.com/AMDESE/linux.git"
@@ -23,8 +27,8 @@ else
 	# qemu commit
 	QEMU_GIT_URL="https://github.com/AMDESE/qemu.git"
 	QEMU_BRANCH="svsm-preview"
-fi
 
-# Guest BIOS (OVMF)
-OVMF_GIT_URL="https://github.com/AMDESE/ovmf"
-OVMF_BRANCH="svsm-preview"
+	# Guest BIOS (OVMF)
+	OVMF_GIT_URL="https://github.com/AMDESE/ovmf.git"
+	OVMF_BRANCH="svsm-preview"
+fi

--- a/scripts/stable-commits
+++ b/scripts/stable-commits
@@ -7,12 +7,12 @@
 if [ "$VTPM" == "1" ]; then
 	echo "VTPM profile selected"
 	# Hypervisor commit
-	KERNEL_GIT_URL="git@github.com:svsm-vtpm/linux.git"
+	KERNEL_GIT_URL="https://github.com/svsm-vtpm/linux.git"
 	KERNEL_HOST_BRANCH="svsm-preview-hv"
 	KERNEL_GUEST_BRANCH="svsm-vtpm-preview-guest"
 
 	# qemu commit
-	QEMU_GIT_URL="git@github.com:svsm-vtpm/qemu.git"
+	QEMU_GIT_URL="https://github.com/svsm-vtpm/qemu.git"
 	QEMU_BRANCH="svsm-vtpm-preview"
 else
 	# Hypervisor commit

--- a/src/bios.rs
+++ b/src/bios.rs
@@ -88,7 +88,7 @@ struct SnpSection {
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
-struct SnpSecrets {
+pub struct SnpSecrets {
     version: u32,
     flags: u32,
     fms: u32,
@@ -96,7 +96,7 @@ struct SnpSecrets {
 
     gosvw: [u8; 16],
 
-    vmpck0: [u8; 32],
+    pub vmpck0: [u8; 32],
     vmpck1: [u8; 32],
     vmpck2: [u8; 32],
     vmpck3: [u8; 32],

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -168,85 +168,85 @@ pub fn vc_terminate(reason_set: u64, reason_code: u64) -> ! {
 
 /// Terminate SVSM with generic SVSM reason
 #[inline]
-pub fn vc_terminate_svsm_general() {
+pub fn vc_terminate_svsm_general() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_GENERAL);
 }
 
 /// Terminate SVSM due to lack of memory
 #[inline]
-pub fn vc_terminate_svsm_enomem() {
+pub fn vc_terminate_svsm_enomem() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_ENOMEM);
 }
 
 /// Terminate SVSM due to firmware configuration error
 #[inline]
-pub fn vc_terminate_svsm_fwcfg() {
+pub fn vc_terminate_svsm_fwcfg() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_FW_CFG_ERROR);
 }
 
 /// Terminate SVSM due to invalid GHCB response
 #[inline]
-pub fn vc_terminate_svsm_resp_invalid() {
+pub fn vc_terminate_svsm_resp_invalid() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_GHCB_RESP_INVALID);
 }
 
 /// Terminate SVSM due to a page-related error
 #[inline]
-pub fn vc_terminate_svsm_page_err() {
+pub fn vc_terminate_svsm_page_err() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_SET_PAGE_ERROR);
 }
 
 /// Terminate SVSM due to a PSC-related error
 #[inline]
-pub fn vc_terminate_svsm_psc() {
+pub fn vc_terminate_svsm_psc() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_PSC_ERROR);
 }
 
 /// Terminate SVSM due to a BIOS-format related error
 #[inline]
-pub fn vc_terminate_svsm_bios() {
+pub fn vc_terminate_svsm_bios() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_BIOS_FORMAT);
 }
 
 /// Terminate SVSM due to an unhandled #VC exception
 #[inline]
-pub fn vc_terminate_unhandled_vc() {
+pub fn vc_terminate_unhandled_vc() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_UNHANDLED_VC);
 }
 
 /// Terminate SVSM with generic GHCB reason
 #[inline]
-pub fn vc_terminate_ghcb_general() {
+pub fn vc_terminate_ghcb_general() -> ! {
     vc_terminate(GHCB_REASON_CODE_SET, GHCB_TERM_GENERAL);
 }
 
 /// Terminate SVSM due to unsupported GHCB protocol
 #[inline]
-pub fn vc_terminate_ghcb_unsupported_protocol() {
+pub fn vc_terminate_ghcb_unsupported_protocol() -> ! {
     vc_terminate(GHCB_REASON_CODE_SET, GHCB_TERM_UNSUPPORTED_PROTOCOL);
 }
 
 /// Terminate SVSM due to error related with feature support
 #[inline]
-pub fn vc_terminate_ghcb_feature() {
+pub fn vc_terminate_ghcb_feature() -> ! {
     vc_terminate(GHCB_REASON_CODE_SET, GHCB_TERM_FEATURE_SUPPORT);
 }
 
 /// Terminate SVSM due to incorrect SEV features for VMPL1
 #[inline]
-pub fn vc_terminate_vmpl1_sev_features() {
+pub fn vc_terminate_vmpl1_sev_features() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_VMPL1_SEV_FEATURES);
 }
 
 /// Terminate SVSM due to incorrect SEV features for VMPL0
 #[inline]
-pub fn vc_terminate_vmpl0_sev_features() {
+pub fn vc_terminate_vmpl0_sev_features() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_VMPL0_SEV_FEATURES);
 }
 
 /// Terminate SVSM due to incorrect VMPL level on VMSA
 #[inline]
-pub fn vc_terminate_svsm_incorrect_vmpl() {
+pub fn vc_terminate_svsm_incorrect_vmpl() -> ! {
     vc_terminate(SVSM_REASON_CODE_SET, SVSM_TERM_INCORRECT_VMPL);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod cpu;
 pub mod globals;
 /// Prepare page table, handle memory (de)allocations
 pub mod mem;
+/// PSP firmware messages
+pub mod psp;
 /// Handle requests from the SVSM guest
 pub mod svsm_request;
 /// Auxiliary functions and macros

--- a/src/mem/alloc.rs
+++ b/src/mem/alloc.rs
@@ -605,7 +605,7 @@ fn allocate_slab_page(slab: VirtAddr) -> Result<VirtAddr, ()> {
     ROOT_MEM.lock().allocate_slab_page(slab)
 }
 
-fn free_page(vaddr: VirtAddr) {
+pub fn free_page(vaddr: VirtAddr) {
     ROOT_MEM.lock().free_page(vaddr)
 }
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -25,6 +25,7 @@ pub use crate::mem::alloc::mem_free_frame;
 pub use crate::mem::alloc::mem_free_frames;
 pub use crate::mem::alloc::mem_init;
 pub use crate::mem::alloc::sizeof_alloc;
+pub use crate::mem::alloc::free_page;
 
 pub use crate::mem::pgtable::pgtable_init;
 pub use crate::mem::pgtable::pgtable_make_pages_np;

--- a/src/mem/pgtable.rs
+++ b/src/mem/pgtable.rs
@@ -70,14 +70,12 @@ fn remap_page(page: Page, page_type: PageType, flush: bool) {
     let mut allocator: PageTableAllocator = PageTableAllocator::new();
 
     unsafe {
-        let mut pa: PhysAddr = PhysAddr::new(0);
-
         let result: Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> =
             PGTABLE.lock().unmap(page);
-        match result {
-            Ok(r) => pa = r.0.start_address(),
+        let pa: PhysAddr = match result {
+            Ok(r) => r.0.start_address(),
             Err(_e) => vc_terminate_svsm_page_err(),
-        }
+        };
 
         let map_pa: PhysAddr;
         if page_type == PageType::Private {

--- a/src/psp/guest_request.rs
+++ b/src/psp/guest_request.rs
@@ -1,0 +1,299 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (C) 2022 IBM
+ *
+ * Authors:
+ *   Claudio Carvalho <cclaudio@linux.ibm.com>
+ */
+
+use alloc::boxed::Box;
+use core::mem::MaybeUninit;
+use crate::{
+    PAGE_SIZE,
+    prints,
+    svsm_secrets_page,
+};
+use crate::bindings::{
+    Aes,
+    AES_BLOCK_SIZE,
+    INVALID_DEVID,
+    wc_AesInit,
+    wc_AesGcmDecrypt,
+    wc_AesGcmEncrypt,
+    wc_AesGcmSetKey,
+};
+use crate::bios::SnpSecrets;
+use crate::cpu::vc::{
+    vc_terminate_svsm_enomem,
+    vc_snp_guest_request,
+};
+use crate::mem::{
+    free_page,
+    mem_allocate_frame,
+    pgtable_make_pages_shared,
+    pgtable_make_pages_private,
+    pgtable_pa_to_va,
+};
+use crate::util::locking::SpinLock;
+use lazy_static::lazy_static;
+use memoffset::offset_of;
+use x86_64::{
+    PhysAddr,
+    VirtAddr,
+};
+use x86_64::structures::paging::PhysFrame;
+
+// AEAD Algo
+#[allow(dead_code)]
+const SNP_AEAD_INVALID: u8 = 0;
+const SNP_AEAD_AES_256_GCM: u8 = 1;
+
+// SNP_GUEST_MESSAGE type
+pub const SNP_MSG_TYPE_INVALID: u8 = 0;
+pub const SNP_MSG_CPUID_REQ: u8 = 1;
+pub const SNP_MSG_CPUID_RSP: u8 = 2;
+pub const SNP_MSG_KEY_REQ: u8 = 3;
+pub const SNP_MSG_KEY_RSP: u8 = 4;
+pub const SNP_MSG_REPORT_REQ: u8 = 5;
+pub const SNP_MSG_REPORT_RSP: u8 = 6;
+pub const SNP_MSG_EXPORT_REQ: u8 = 7;
+pub const SNP_MSG_EXPORT_RSP: u8 = 8;
+pub const SNP_MSG_IMPORT_REQ: u8 = 9;
+pub const SNP_MSG_IMPORT_RSP: u8 = 10;
+pub const SNP_MSG_ABSORB_REQ: u8 = 11;
+pub const SNP_MSG_ABSORB_RSP: u8 = 12;
+pub const SNP_MSG_VMRK_REQ: u8 = 13;
+pub const SNP_MSG_VMRK_RSP: u8 = 14;
+pub const SNP_MSG_ABSORB_NOMA_REQ: u8 = 15;
+pub const SNP_MSG_ABSORB_NOMA_RESP: u8 = 16;
+pub const SNP_MSG_TSC_INFO_REQ: u8 = 17;
+pub const SNP_MSG_TSC_INFO_RSP: u8 = 18;
+
+const HDR_VERSION: u8 = 1;
+const MSG_VERSION: u8 = 1;
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct snp_guest_request_msg_hdr {
+    pub authtag: [u8; 32usize],
+    pub msg_seqno: u64,
+    pub rsvd1: [u8; 8usize],
+    pub algo: u8,
+    pub hdr_version: u8,
+    pub hdr_sz: u16,
+    pub msg_type: u8,
+    pub msg_version: u8,
+    pub msg_sz: u16,
+    pub rsvd2: u32,
+    pub msg_vmpck: u8,
+    pub rsvd3: [u8; 35usize],
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct snp_guest_request_msg {
+    pub hdr: snp_guest_request_msg_hdr,
+    pub payload: [u8; 4000usize],
+}
+
+struct SequenceNumber {
+    data: u64,
+}
+
+impl SequenceNumber {
+    pub const fn new() -> Self {
+        SequenceNumber { data: 0 }
+    }
+    pub fn last_used(&self) -> u64 {
+        self.data
+    }
+    pub fn add_two(&mut self) {
+        self.data = self.data
+            .checked_add(2)
+            .expect("ERROR: Sequence number overflow (2)\n");
+    }
+}
+
+pub struct SnpGuestRequest {
+    seq_num: SequenceNumber,
+}
+
+lazy_static! {
+    static ref GUEST_REQUEST: SpinLock<SnpGuestRequest> =
+        SpinLock::new(SnpGuestRequest::new());
+}
+
+impl SnpGuestRequest {
+    pub fn new() -> Self{
+        SnpGuestRequest {
+            seq_num: SequenceNumber::new(),
+        }
+    }
+    fn send(&mut self, payload: &[u8], msg_type: u8) -> Option<Box<[u8]>> {
+        // The Guest Request NAE event requires two unique pages, one page
+        // for the request and one for the response messages. Both pages
+        // must be assigned to the hypervisor (shared). The payload of the
+        // two messages are encrypted during the communication with the
+        // PSP firmware.
+        let pa1: PhysFrame = match mem_allocate_frame() {
+            Some(f) => f,
+            None => vc_terminate_svsm_enomem(),
+        };
+        let pa2: PhysFrame = match mem_allocate_frame() {
+            Some(f) => f,
+            None => vc_terminate_svsm_enomem(),
+        };
+        let va1: VirtAddr = pgtable_pa_to_va(pa1.start_address());
+        let va2: VirtAddr = pgtable_pa_to_va(pa2.start_address());
+        pgtable_make_pages_shared(va1, PAGE_SIZE);
+        pgtable_make_pages_shared(va2, PAGE_SIZE);
+        let req_msg: *mut snp_guest_request_msg = va1.as_mut_ptr();
+        let resp_msg: *mut snp_guest_request_msg = va2.as_mut_ptr();
+        //
+        // The PSP firmware adds 1 to the sequence number when
+        // it receives a request successfully. Hence, we have to
+        // add 2 ONLY when we receive a response successfully
+        //
+        let mut seq_num: u64 = self.seq_num
+            .last_used()
+            .checked_add(1)
+            .expect("ERROR: Request sequence number overflow\n");
+        //
+        // Use the sequence number as IV
+        //
+        const IV_SIZE: usize = 12;
+        const U64_SIZE: usize = core::mem::size_of::<u64>();
+        let mut iv = [0u8; IV_SIZE];
+        iv[..U64_SIZE].copy_from_slice(&u64::to_ne_bytes(seq_num));
+        //
+        // Use vmpck[0] as key
+        //
+        const KEY_SIZE: usize = 32;
+        let svsm_secrets_va: VirtAddr = unsafe { pgtable_pa_to_va(PhysAddr::new(svsm_secrets_page)) };
+        let svsm_secrets: *const SnpSecrets = svsm_secrets_va.as_ptr();
+        let key = unsafe { *(&(*svsm_secrets).vmpck0 as *const _ as *const [u8; KEY_SIZE]) };
+        //
+        // Request message header
+        //
+        let mut req_hdr = unsafe { &mut (*req_msg).hdr };
+        req_hdr.msg_seqno = seq_num;
+        req_hdr.algo = SNP_AEAD_AES_256_GCM;
+        req_hdr.hdr_version = HDR_VERSION;
+        req_hdr.hdr_sz = core::mem::size_of::<snp_guest_request_msg_hdr>().try_into().unwrap();
+        req_hdr.msg_type = msg_type;
+        req_hdr.msg_version = MSG_VERSION;
+        req_hdr.msg_sz = core::mem::size_of_val(payload).try_into().unwrap();
+        req_hdr.msg_vmpck = 0;
+        //
+        // Encrypt the request payload
+        //
+        let aad_len: usize =
+            core::mem::size_of::<snp_guest_request_msg_hdr>() -
+            offset_of!(snp_guest_request_msg_hdr, algo);
+        unsafe {
+            let mut enc: Aes = MaybeUninit::zeroed().assume_init();
+            let mut ret: i32 = wc_AesInit(&mut enc, core::ptr::null_mut(), INVALID_DEVID);
+            if ret != 0 {
+                prints!("ERROR: AesInit failed for encryption, ret={}\n", ret);
+                return None;
+            }
+            ret = wc_AesGcmSetKey(
+                &mut enc,
+                &key as *const _ as *const u8,
+                KEY_SIZE as u32
+            );
+            if ret != 0 {
+                prints!("ERROR: AesGcmSetKey failed for encryption, ret={}\n", ret);
+                return None;
+            }
+            ret = wc_AesGcmEncrypt(
+                &mut enc,
+                (*req_msg).payload.as_mut_ptr(),        // [out] cipher text
+                payload.as_ptr(),                       // [in] plain text
+                core::mem::size_of_val(payload) as u32, // [in] plain text size
+                &mut iv as *mut _ as *mut u8,           // [in] iv
+                IV_SIZE as u32,                         // [in] iv size
+                (*req_msg).hdr.authtag.as_mut_ptr(),    // [out] authtag
+                AES_BLOCK_SIZE as u32,                  // [in] authtag size
+                &(*req_msg).hdr.algo as *const u8,      // [in] aad
+                aad_len as u32                          // [in] aad size
+            );
+            if ret != 0 {
+                prints!("ERROR: AesGcmEncrypt failed, ret={}\n", ret);
+                return None;
+            } else {
+                prints!("INFO: SNP_GUEST_REQUEST message encrypted\n");
+//              prints!("req_msg {:p} {:x?}\n", {&(*req_msg)}, {&(*req_msg)});
+            }
+        }
+        //
+        // Send the request
+        //
+        let rc = vc_snp_guest_request(pa1.start_address(), pa2.start_address());
+        if rc != 0 {
+            return None;
+        }
+        self.seq_num.add_two();
+        const BUF_LEN: usize = 4000;
+        let mut buf: [u8; BUF_LEN] = [0u8; BUF_LEN];
+        unsafe {
+//          prints!("resp_msg {:p} {:x?}\n", {&(*resp_msg)}, {&(*resp_msg)});
+            //
+            // Check the response
+            //
+            seq_num = seq_num.checked_add(1)
+                .expect("ERROR: Sequence number overflow\n");
+            if (*resp_msg).hdr.msg_seqno != seq_num {
+                prints!("ERROR: BUG: Response with invalid seq_num={}, expected={}\n",
+                    {(*resp_msg).hdr.msg_seqno},
+                    seq_num);
+                return None;
+            }
+            //
+            // Decrypt the response payload.
+            //
+            let mut dec: Aes = MaybeUninit::zeroed().assume_init();
+            let mut ret: i32 = wc_AesInit(&mut dec, core::ptr::null_mut(), INVALID_DEVID);
+            if ret != 0 {
+                 prints!("ERROR: AesInit failed for decryption, ret={}\n", ret);
+                 return None;
+            }
+            ret = wc_AesGcmSetKey(&mut dec, &key as *const _ as *const u8, 32);
+            if ret != 0 {
+                prints!("ERROR: AesGcmSetKey failed for decryption, ret={}\n", ret);
+                return None;
+            }
+            iv[..U64_SIZE].copy_from_slice(&u64::to_ne_bytes(seq_num));
+            ret = wc_AesGcmDecrypt(
+                &mut dec,
+                buf.as_mut_ptr(),                    // [out] plain text
+                (*resp_msg).payload.as_ptr(),        // [in] cipher text
+                (*resp_msg).hdr.msg_sz as u32,       // [in] plain text size
+                &mut iv as *mut _ as *mut u8,        // [in] iv
+                IV_SIZE as u32,                      // [in] iv size
+                (*resp_msg).hdr.authtag.as_ptr(),    // [in] authtag
+                AES_BLOCK_SIZE as u32,               // [in] authtag size
+                &(*resp_msg).hdr.algo as *const u8,  // [in] aad
+                aad_len as u32                       // [in] aad size
+            );
+            if ret != 0 {
+                prints!("ERROR: AesGcmDecrypt failed, ret={}\n", ret);
+                return None;
+            } else {
+                prints!("INFO: SNP_GUEST_REQUEST message decrypted\n");
+            }
+        }
+        //
+        // Free the two shared pages
+        //
+        pgtable_make_pages_private(va1, PAGE_SIZE);
+        pgtable_make_pages_private(va2, PAGE_SIZE);
+        free_page(va1);
+        free_page(va2);
+        Some(buf.into())
+    }
+}
+
+pub fn send_guest_request(payload: &[u8], msg_type: u8) -> Option<Box<[u8]>> {
+    GUEST_REQUEST.lock().send(payload, msg_type)
+}

--- a/src/psp/guest_request.rs
+++ b/src/psp/guest_request.rs
@@ -7,6 +7,8 @@
  */
 
 use alloc::boxed::Box;
+use alloc::string::ToString;
+use core::fmt;
 use core::mem::MaybeUninit;
 use crate::{
     PAGE_SIZE,
@@ -42,6 +44,103 @@ use x86_64::{
     VirtAddr,
 };
 use x86_64::structures::paging::PhysFrame;
+
+// From Linux/include/uapi/linux/psp-sev.h
+#[repr(u32)]
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Debug)]
+pub enum SevStatusCode {
+    SEV_RET_SUCCESS = 0,
+    SEV_RET_INVALID_PLATFORM_STATE,
+    SEV_RET_INVALID_GUEST_STATE,
+    SEV_RET_INAVLID_CONFIG,
+    SEV_RET_INVALID_LEN,
+    SEV_RET_ALREADY_OWNED,
+    SEV_RET_INVALID_CERTIFICATE,
+    SEV_RET_POLICY_FAILURE,
+    SEV_RET_INACTIVE,
+    SEV_RET_INVALID_ADDRESS,
+    SEV_RET_BAD_SIGNATURE,
+    SEV_RET_BAD_MEASUREMENT,
+    SEV_RET_ASID_OWNED,
+    SEV_RET_INVALID_ASID,
+    SEV_RET_WBINVD_REQUIRED,
+    SEV_RET_DFFLUSH_REQUIRED,
+    SEV_RET_INVALID_GUEST,
+    SEV_RET_INVALID_COMMAND,
+    SEV_RET_ACTIVE,
+    SEV_RET_HWSEV_RET_PLATFORM,
+    SEV_RET_HWSEV_RET_UNSAFE,
+    SEV_RET_UNSUPPORTED,
+    SEV_RET_INVALID_PARAM,
+    SEV_RET_RESOURCE_LIMIT,
+    SEV_RET_SECURE_DATA_INVALID,
+}
+
+impl SevStatusCode {
+    pub fn from_u32(value: u32) -> Option<SevStatusCode> {
+        match value {
+            0 => Some(SevStatusCode::SEV_RET_SUCCESS),
+            1 => Some(SevStatusCode::SEV_RET_INVALID_PLATFORM_STATE),
+            2 => Some(SevStatusCode::SEV_RET_INVALID_GUEST_STATE),
+            3 => Some(SevStatusCode::SEV_RET_INAVLID_CONFIG),
+            4 => Some(SevStatusCode::SEV_RET_INVALID_LEN),
+            5 => Some(SevStatusCode::SEV_RET_ALREADY_OWNED),
+            6 => Some(SevStatusCode::SEV_RET_INVALID_CERTIFICATE),
+            7 => Some(SevStatusCode::SEV_RET_POLICY_FAILURE),
+            8 => Some(SevStatusCode::SEV_RET_INACTIVE),
+            9 => Some(SevStatusCode::SEV_RET_INVALID_ADDRESS),
+            10 => Some(SevStatusCode::SEV_RET_BAD_SIGNATURE),
+            11 => Some(SevStatusCode::SEV_RET_BAD_MEASUREMENT),
+            12 => Some(SevStatusCode::SEV_RET_ASID_OWNED),
+            13 => Some(SevStatusCode::SEV_RET_INVALID_ASID),
+            14 => Some(SevStatusCode::SEV_RET_WBINVD_REQUIRED),
+            15 => Some(SevStatusCode::SEV_RET_DFFLUSH_REQUIRED),
+            16 => Some(SevStatusCode::SEV_RET_INVALID_GUEST),
+            17 => Some(SevStatusCode::SEV_RET_INVALID_COMMAND),
+            18 => Some(SevStatusCode::SEV_RET_ACTIVE),
+            19 => Some(SevStatusCode::SEV_RET_HWSEV_RET_PLATFORM),
+            20 => Some(SevStatusCode::SEV_RET_HWSEV_RET_UNSAFE),
+            21 => Some(SevStatusCode::SEV_RET_UNSUPPORTED),
+            22 => Some(SevStatusCode::SEV_RET_INVALID_PARAM),
+            23 => Some(SevStatusCode::SEV_RET_RESOURCE_LIMIT),
+            24 => Some(SevStatusCode::SEV_RET_SECURE_DATA_INVALID),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SevStatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            SevStatusCode::SEV_RET_SUCCESS => f.write_str("SEV_RET_SUCCESS"),
+            SevStatusCode::SEV_RET_INVALID_PLATFORM_STATE => f.write_str("SEV_RET_INVALID_PLATFORM_STATE"),
+            SevStatusCode::SEV_RET_INVALID_GUEST_STATE => f.write_str("SEV_RET_INVALID_GUEST_STATE"),
+            SevStatusCode::SEV_RET_INAVLID_CONFIG => f.write_str("SEV_RET_INAVLID_CONFIG"),
+            SevStatusCode::SEV_RET_INVALID_LEN => f.write_str("SEV_RET_INVALID_LEN"),
+            SevStatusCode::SEV_RET_ALREADY_OWNED => f.write_str("SEV_RET_ALREADY_OWNED"),
+            SevStatusCode::SEV_RET_INVALID_CERTIFICATE => f.write_str("SEV_RET_INVALID_CERTIFICATE"),
+            SevStatusCode::SEV_RET_POLICY_FAILURE => f.write_str("SEV_RET_POLICY_FAILURE"),
+            SevStatusCode::SEV_RET_INACTIVE => f.write_str("SEV_RET_INACTIVE"),
+            SevStatusCode::SEV_RET_INVALID_ADDRESS => f.write_str("SEV_RET_INVALID_ADDRESS"),
+            SevStatusCode::SEV_RET_BAD_SIGNATURE => f.write_str("SEV_RET_BAD_SIGNATURE"),
+            SevStatusCode::SEV_RET_BAD_MEASUREMENT => f.write_str("SEV_RET_BAD_MEASUREMENT"),
+            SevStatusCode::SEV_RET_ASID_OWNED => f.write_str("SEV_RET_ASID_OWNED"),
+            SevStatusCode::SEV_RET_INVALID_ASID => f.write_str("SEV_RET_INVALID_ASID"),
+            SevStatusCode::SEV_RET_WBINVD_REQUIRED => f.write_str("SEV_RET_WBINVD_REQUIRED"),
+            SevStatusCode::SEV_RET_DFFLUSH_REQUIRED => f.write_str("SEV_RET_DFFLUSH_REQUIRED"),
+            SevStatusCode::SEV_RET_INVALID_GUEST => f.write_str("SEV_RET_INVALID_GUEST"),
+            SevStatusCode::SEV_RET_INVALID_COMMAND => f.write_str("SEV_RET_INVALID_COMMAND"),
+            SevStatusCode::SEV_RET_ACTIVE => f.write_str("SEV_RET_ACTIVE"),
+            SevStatusCode::SEV_RET_HWSEV_RET_PLATFORM => f.write_str("SEV_RET_HWSEV_RET_PLATFORM"),
+            SevStatusCode::SEV_RET_HWSEV_RET_UNSAFE => f.write_str("SEV_RET_HWSEV_RET_UNSAFE"),
+            SevStatusCode::SEV_RET_UNSUPPORTED => f.write_str("SEV_RET_UNSUPPORTED"),
+            SevStatusCode::SEV_RET_INVALID_PARAM => f.write_str("SEV_RET_INVALID_PARAM"),
+            SevStatusCode::SEV_RET_RESOURCE_LIMIT => f.write_str("SEV_RET_RESOURCE_LIMIT"),
+            SevStatusCode::SEV_RET_SECURE_DATA_INVALID => f.write_str("SEV_RET_SECURE_DATA_INVALID"),
+        }
+    }
+}
 
 // AEAD Algo
 #[allow(dead_code)]
@@ -231,6 +330,11 @@ impl SnpGuestRequest {
         //
         let rc = vc_snp_guest_request(pa1.start_address(), pa2.start_address());
         if rc != 0 {
+            let status = match SevStatusCode::from_u32(rc) {
+                Some(s) => s.to_string(),
+                None => "Unknown".to_string(),
+            };
+            prints!("ERROR: SNP_GUEST_REQUEST failed, status={} {}\n", rc, status);
             return None;
         }
         self.seq_num.add_two();

--- a/src/psp/mod.rs
+++ b/src/psp/mod.rs
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (C) 2022 IBM
+ *
+ * Authors:
+ *   Claudio Carvalho <cclaudio@linux.ibm.com>
+ */
+
+/// SNP Guest Request Messages
+pub mod guest_request;
+
+pub use crate::psp::guest_request::send_guest_request;

--- a/src/vtpm/init.rs
+++ b/src/vtpm/init.rs
@@ -228,7 +228,7 @@ pub fn send_tpm_command(request: &mut [u8]) -> TpmResponse {
     let mut _resp_vec: *mut u8 = __resp_vec.as_mut_ptr();
     unsafe {
         let resp_vec: *mut *mut u8 = &mut _resp_vec as *mut *mut u8;
-
+//        prints!("TPM Request: len={:#x} {:02x?}\n", {request.len()}, request);
         ExecuteCommand(
             request.len() as u32,
             request.as_mut_ptr(),
@@ -237,6 +237,7 @@ pub fn send_tpm_command(request: &mut [u8]) -> TpmResponse {
         );
         __resp_vec.set_len(__resp_sz as usize);
     }
+//    prints!("TPM Response: len={:#x} {:02x?}\n", __resp_sz, {&__resp_vec});
     let tpm_resp: TpmResponse = TpmResponse {
         data: __resp_vec,
     };

--- a/src/vtpm/init.rs
+++ b/src/vtpm/init.rs
@@ -20,6 +20,7 @@ use super::manufacture::{
     tpm2_create_ek_rsa2048,
     tpm2_get_ek_pub,
 };
+use super::report::get_and_save_report;
 
 use tock_registers::{
     interfaces::{ReadWriteable, Readable, Writeable},
@@ -270,6 +271,8 @@ pub fn vtpm_init() {
 
         rpc_signal_power_on(false);
     }
+    // cmd1: TPM2_CC_SelfTest
+    // cmd2: TPM2_CC_Startup
     let mut cmd1: &mut [u8] = &mut [
         0x80, 0x01, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x01, 0x43, 0x00,
     ];
@@ -301,6 +304,7 @@ pub fn vtpm_init() {
             return;
         }
     }
+    get_and_save_report(&ek_pub_digest)
 }
 
 pub fn handle_tpm2_crb_request(addr: u32, val: u64) {

--- a/src/vtpm/mod.rs
+++ b/src/vtpm/mod.rs
@@ -8,5 +8,6 @@
 
 pub mod init;
 pub mod manufacture;
+pub mod report;
 
 pub use crate::vtpm::init::vtpm_init;

--- a/src/vtpm/mod.rs
+++ b/src/vtpm/mod.rs
@@ -10,4 +10,3 @@ pub mod init;
 pub mod manufacture;
 
 pub use crate::vtpm::init::vtpm_init;
-pub use crate::vtpm::manufacture::{tpm2_create_ek, KeyType};

--- a/src/vtpm/report.rs
+++ b/src/vtpm/report.rs
@@ -7,6 +7,7 @@
  */
 
 use core::slice;
+use crate::manufacture::tpm2_write_report_nvram;
 use crate::prints;
 use crate::psp::guest_request::{
     send_guest_request,

--- a/src/vtpm/report.rs
+++ b/src/vtpm/report.rs
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (C) 2022 IBM
+ *
+ * Authors:
+ *   Claudio Carvalho <cclaudio@linux.ibm.com>
+ */
+
+use core::slice;
+use crate::prints;
+use crate::psp::guest_request::{
+    send_guest_request,
+    SNP_MSG_REPORT_REQ,
+};
+
+pub const REPORT_REQ_USER_DATA_SIZE: usize = 64;
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct snp_report_req {
+    pub user_data: [u8; REPORT_REQ_USER_DATA_SIZE],
+    pub vmpl: u32,
+    pub rsvd: [u8; 28usize],
+}
+
+impl snp_report_req {
+    fn new(_vmpl: u32) -> Self {
+        Self {
+            user_data: [0u8; 64],
+            vmpl: _vmpl,
+            rsvd: [0u8; 28],
+        }
+    }
+    fn as_slice(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(
+                self as *const snp_report_req as *const u8,
+                core::mem::size_of::<snp_report_req>()
+            )
+        }
+    }
+}
+
+#[repr(C)]
+#[repr(align(2048))]
+#[derive(Debug, Copy, Clone)]
+pub struct msg_report_resp {
+    pub status: u32,
+    pub report_size: u32,
+    pub reserved: [u8; 24usize],
+    pub report: attestation_report,
+}
+
+// Converted tcb_version from enum to
+// struct to make alignment simple.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcb_version {
+    pub raw: u64,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct signature {
+    pub r: [u8; 72usize],
+    pub s: [u8; 72usize],
+    pub reserved: [u8; 368usize],
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct attestation_report {
+    pub version: u32,
+    pub guest_svn: u32,
+    pub policy: u64,
+    pub family_id: [u8; 16usize],
+    pub image_id: [u8; 16usize],
+    pub vmpl: u32,
+    pub signature_algo: u32,
+    pub platform_version: tcb_version,
+    pub platform_info: u64,
+    pub flags: u32,
+    pub reserved0: u32,
+    pub report_data: [u8; 64usize],
+    pub measurement: [u8; 48usize],
+    pub host_data: [u8; 32usize],
+    pub id_key_digest: [u8; 48usize],
+    pub author_key_digest: [u8; 48usize],
+    pub report_id: [u8; 32usize],
+    pub report_id_ma: [u8; 32usize],
+    pub reported_tcb: tcb_version,
+    pub reserved1: [u8; 24usize],
+    pub chip_id: [u8; 64usize],
+    pub reserved2: [u8; 192usize],
+    pub signature: signature,
+}
+
+impl attestation_report {
+    fn as_slice(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(
+                self as *const attestation_report as *const u8,
+                core::mem::size_of::<attestation_report>()
+            )
+        }
+    }
+}
+
+// Secure Encrypted Virtualization API spec, Attestation section
+pub fn get_and_save_report(data: &[u8]) {
+    let data_sz: usize = data.len();
+    if data_sz > REPORT_REQ_USER_DATA_SIZE {
+        prints!("ERROR: Report data_size={} too big\n", data_sz);
+        return;
+    }
+    // Create a vmpl0 request
+    let mut req: snp_report_req = snp_report_req::new(0u32);
+    req.user_data[..data_sz].copy_from_slice(data);
+
+    prints!("INFO: Attestation report requested. user_data: {:02x?}\n", {req.user_data});
+
+    let payload = send_guest_request(req.as_slice(), SNP_MSG_REPORT_REQ);
+    if payload.is_none() {
+        prints!("ERROR: Attestation report request failed\n");
+        return;
+    }
+    let resp: msg_report_resp = {
+            let r = payload.unwrap();
+            let (head, body, _tail) = unsafe { r.align_to::<msg_report_resp>() };
+            if !head.is_empty() {
+                prints!("ERROR: Report response not aligned\n");
+                return;
+            }
+            body[0]
+    };
+    if resp.status != 0 {
+        prints!("ERROR: Bad report status={}\n", {resp.status});
+        return;
+    }
+    const REPORT_LEN: usize = core::mem::size_of::<attestation_report>();
+    if resp.report_size != REPORT_LEN as u32 {
+        prints!("ERROR: Report size mismatch (size=0x{}, expected=0x{})\n",
+            {resp.report_size},
+            REPORT_LEN);
+        return;
+    }
+    tpm2_write_report_nvram(resp.report.as_slice());
+}


### PR DESCRIPTION
This patch series get a vmpl0 attestation report and saves it in the TPM NV. A sha512 hash of the TPM EKpub is fed into the request "user_data" field.