### PR TITLE
build: use -fPIE for wolfssl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,7 +91,7 @@ fn main() {
     ];
 
     let wolfssl_cflags = format!(
-        "-fno-stack-protector -nostdinc -Wno-error=float-equal -I{} -I{} -I{}",
+        "-fno-stack-protector -fPIE -nostdinc -Wno-error=float-equal -I{} -I{} -I{}",
         Path::new(&wolfssl_src).join("amd-svsm").to_str().unwrap(),
         Path::new(&libcrt_src).join("include").to_str().unwrap(),
         Path::new(&libm_src).join("include").to_str().unwrap()


### PR DESCRIPTION
The Ubuntu GCC build has --enable-default-pie, but this can't be assumed for all platforms. On Fedora this is not used and thus linking fails with

```
    gcc -m64 -nostdlib -Wl,-Tsrc/start/svsm.lds -Wl,--build-id=none -o svsm.bin.elf src/start/start.o target/x86_64-unknown-none/debug/liblinux_svsm.a -Wl,--start-group ./external/build/lib/libtpm.a ./external/build/lib/libplatform.a ./external/build/lib/libwolfssl.a ./external/build/lib/libcrt.a ./external/build/lib/libm.a -Wl,--end-group
    ./external/build/lib/libwolfssl.a(src_libwolfssl_la-sha256.o): in function `Transform_Sha256':
    sha256.c:(.text+0xba): relocation truncated to fit: R_X86_64_32 against `.rodata'
    ./external/build/lib/libwolfssl.a(src_libwolfssl_la-aes.o): in function `wc_AesEncrypt':
    aes.c:(.text+0x50): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0x68): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0x7e): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0x8c): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0x9e): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0xa9): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0xc5): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0xd3): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0xe9): relocation truncated to fit: R_X86_64_32S against `.rodata'
    aes.c:(.text+0xf8): additional relocation overflows omitted from the output
    collect2: error: ld returned 1 exit status

```
adding `-fPIE` to the wolfssl CFLAGS solves that failure.

Note, this isn't sufficient on  its own to solve the linkage issues. We also need to add `-fPIE` to libcrt and libm, but I can't do that in this patch since they are git submodules and there's no nice way to override their CFLAGS from build.rs.