### PR TITLE
Build.rs improvements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -251,6 +251,9 @@ fn main() {
                 .to_str()
                 .unwrap()
         ))
+        .clang_arg(
+            "-I/usr/include/x86_64-linux-gnu/"
+        )
         .header("libtpm.h")
         .generate()
         .expect("Unable to generate bindings");

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn build_library(src_dir: &str, commands: &Vec<CommandWithArgs>) {
     env::set_current_dir(src_dir).expect("failed to cd to build directory");
 
     for cmd in commands {
+        println!("=== Cwd    : {} ", src_dir);
+        println!("=== Running: {} {}", cmd.0, cmd.1.join(" "));
         Command::new(&cmd.0)
             .args(&cmd.1)
             .stdout(Stdio::inherit())


### PR DESCRIPTION
Some small improvements to `build.rs`

- Check return code of external commands when building the C libraries.
- Include the working directory and the command (incl. arguments) in the log when running external commands.
- Fix the include path for clang. This is needed when building in a plain Ubuntu 22.04 or Fedora 37 container.